### PR TITLE
Manejo de Errores, CRUD y Nueva Entidad

### DIFF
--- a/lib/api/service/categorias_service.dart
+++ b/lib/api/service/categorias_service.dart
@@ -1,0 +1,88 @@
+import 'package:diego/constants/constants.dart';
+import 'package:diego/data/repositories/categoria_repository.dart';
+import 'package:diego/domain/entities/categoria.dart';
+import 'package:diego/exceptions/api_exceptions.dart';
+
+class CategoriaService {
+  final CategoriaRepository _repository = CategoriaRepository();
+
+  /// Obtiene todas las categorías desde el repositorio
+  Future<List<Categoria>> getCategorias() async {
+    try {
+      return await _repository.getCategorias();
+    } catch (e) {
+      if (e is ApiException) {
+        // Verificar si es un error de timeout específicamente
+        if (e.statusCode == 408) {
+          throw Exception(Constants.messageErrorTimeout);
+        }
+        // Propaga el mensaje contextual de ApiException
+        rethrow;
+      } else {
+        throw Exception('Error desconocido: $e');
+      }
+    }
+  }
+
+  /// Crea una nueva categoría
+  Future<void> crearCategoria(Categoria categoria) async {
+    try {
+      await _repository.crearCategoria(categoria.toJson());
+    } catch (e) {
+      if (e is ApiException) {
+        // Verificar si es un error de timeout específicamente
+        if (e.statusCode == 408) {
+          throw Exception(Constants.messageErrorTimeout);
+        }
+        // Propaga el mensaje contextual de ApiException
+        throw Exception('Error en el servicio de categorías: ${e.message}');
+      } else {
+        throw Exception('Error desconocido: $e');
+      }
+    }
+  }
+
+  /// Edita una categoría existente
+  Future<void> editarCategoria(String? id, Categoria categoria) async {
+    try {
+      if (id == null) {
+        throw Exception('El ID no puede ser nulo');
+      }
+      await _repository.editarCategoria(id, categoria.toJson());
+    } catch (e) {
+      if (e is ApiException) {
+        // Verificar si es un error de timeout específicamente
+        if (e.statusCode == 408) {
+          throw Exception(Constants.messageErrorTimeout);
+        }
+        // Propaga el mensaje contextual de ApiException
+        throw Exception('Error en el servicio de categorías: ${e.message}');
+      } else {
+        throw Exception('Error desconocido: $e');
+      }
+    }
+  }
+
+  /// Elimina una categoría
+  Future<void> eliminarCategoria(String? id) async {
+    try {
+      // Validar que el ID no sea nulo
+      if (id == null || id.isEmpty) {
+        throw Exception('El ID de la categoría no puede ser nulo o vacío');
+      }
+
+      await _repository.eliminarCategoria(id);
+    } catch (e) {
+      if (e is ApiException) {
+        // Verificar si es un error de timeout específicamente
+        if (e.statusCode == 408) {
+          throw Exception(Constants.messageErrorTimeout);
+        }
+        // Propaga el mensaje contextual de ApiException
+        throw Exception('Error en el servicio de categorías: ${e.message}');
+      } else {
+        throw Exception('Error desconocido: $e');
+      }
+    }
+  }
+}

--- a/lib/constants/constants.dart
+++ b/lib/constants/constants.dart
@@ -29,9 +29,15 @@ class Constants {
   static const String listaVaciaNoticia = 'No hay noticias disponibles';
   static const String mensajeError = 'Error al cargar noticias';
   static const double espaciadoAlto = 10.0;
-  //static const newUrl =
-      //'https://crudcrud.com/api/3cc4f821fffa4ee381e907826a2061dc/noticias';
-  static const String apiKey = '3cc4f821fffa4ee381e907826a2061dc';
   static String get newUrl => dotenv.env['NEW_URL'] ?? '';
+  static String  get urlNoticias => '$newUrl/noticias';
+  static String get urlCategorias => '$newUrl/categorias'; 
+  static String defaultCategoriaId = 'Sin categoría'; 
+  static int timeOutSeconds = 10; // Tiempo de espera para las peticiones HTTP
+  static String messageError = 'Error al cargar las categorías';
+  static String messageErrorTimeout = 'Tiempo de espera agotado';
+  static const String errorUnauthorized = 'No autorizado';
+  static const String errorNotFound = 'Noticias no encontradas';
+  static const String errorServer = 'Error del servidor';
 
 }

--- a/lib/data/repositories/categoria_repository.dart
+++ b/lib/data/repositories/categoria_repository.dart
@@ -1,0 +1,133 @@
+import 'package:diego/constants/constants.dart';
+import 'package:diego/domain/entities/categoria.dart';
+import 'package:dio/dio.dart';
+import 'package:diego/exceptions/api_exceptions.dart';
+
+class CategoriaRepository {
+
+  CategoriaRepository() : _dio = Dio() {
+    // Configurar tiempo máximo de espera para todas las peticiones
+    _dio.options.connectTimeout =  Duration(milliseconds: Constants.timeOutSeconds * 1000);
+    _dio.options.receiveTimeout =  Duration(milliseconds: Constants.timeOutSeconds * 1000);
+    
+  }
+  final Dio _dio;
+
+  /// Obtiene todas las categorías desde la API
+  Future<List<Categoria>> getCategorias() async {
+    try {
+      final response = await _dio.get(Constants.urlCategorias);
+
+      if (response.statusCode == 200) {
+        final List<dynamic> categoriasJson = response.data;
+        return categoriasJson.map((json) => Categoria.fromJson(json)).toList();
+      } else {
+        throw ApiException(
+          'Error al obtener las categorías',
+          statusCode: response.statusCode,
+        );
+      }
+    } on DioException catch (e) {
+      if (e.type == DioExceptionType.connectionTimeout ||
+          e.type == DioExceptionType.receiveTimeout ||
+          e.type == DioExceptionType.sendTimeout) {
+        throw ApiException(
+          'Tiempo de espera agotado',
+          statusCode: 408, // Código HTTP para Request Timeout
+        );
+      }
+      throw ApiException(
+        'Error al conectar con la API de categorías: ${e.message}',
+        statusCode: e.response?.statusCode,
+      );
+    } catch (e) {
+      throw ApiException('Error desconocido: $e');
+    }
+  }
+
+  /// Crea una nueva categoría en la API
+  Future<void> crearCategoria(Map<String, dynamic> categoria) async {
+    try {
+      final response = await _dio.post(
+        Constants.urlCategorias,
+        data: categoria,
+      );
+
+      if (response.statusCode != 201) {
+        throw ApiException(
+          'Error al crear la categoría',
+          statusCode: response.statusCode,
+        );
+      }
+    } on DioException catch (e) {
+      if (e.type == DioExceptionType.connectionTimeout ||
+          e.type == DioExceptionType.receiveTimeout ||
+          e.type == DioExceptionType.sendTimeout) {
+        throw ApiException('Tiempo de espera agotado', statusCode: 408);
+      }
+      throw ApiException(
+        'Error al conectar con la API de categorías: ${e.message}',
+        statusCode: e.response?.statusCode,
+      );
+    } catch (e) {
+      throw ApiException('Error desconocido: $e');
+    }
+  }
+
+  /// Edita una categoría existente en la API
+  Future<void> editarCategoria(
+    String id,
+    Map<String, dynamic> categoria,
+  ) async {
+    try {
+      final url = '${Constants.urlCategorias}/$id';
+      final response = await _dio.put(url, data: categoria);
+
+      if (response.statusCode != 200) {
+        throw ApiException(
+          'Error al editar la categoría',
+          statusCode: response.statusCode,
+        );
+      }
+    } on DioException catch (e) {
+      if (e.type == DioExceptionType.connectionTimeout ||
+          e.type == DioExceptionType.receiveTimeout ||
+          e.type == DioExceptionType.sendTimeout) {
+        throw ApiException('Tiempo de espera agotado', statusCode: 408);
+      }
+      throw ApiException(
+        'Error al conectar con la API de categorías: ${e.message}',
+        statusCode: e.response?.statusCode,
+      );
+    } catch (e) {
+      throw ApiException('Error desconocido: $e');
+    }
+  }
+
+  /// Elimina una categoría de la API
+  Future<void> eliminarCategoria(String id) async {
+    try {
+      final url = '${Constants.urlCategorias}/$id';
+      final response = await _dio.delete(url);
+
+      if (response.statusCode != 200 && response.statusCode != 204) {
+        throw ApiException(
+          'Error al eliminar la categoría',
+          statusCode: response.statusCode,
+        );
+      }
+    } on DioException catch (e) {
+      if (e.type == DioExceptionType.connectionTimeout ||
+          e.type == DioExceptionType.receiveTimeout ||
+          e.type == DioExceptionType.sendTimeout) {
+        throw ApiException('Tiempo de espera agotado', statusCode: 408);
+      }
+      throw ApiException(
+        'Error al conectar con la API de categorías: ${e.message}',
+        statusCode: e.response?.statusCode,
+      );
+    } catch (e) {
+      throw ApiException('Error desconocido: $e');
+    }
+  }
+}

--- a/lib/domain/entities/categoria.dart
+++ b/lib/domain/entities/categoria.dart
@@ -1,0 +1,34 @@
+// category.dart
+class Categoria {
+  final String? id; // ID asignado por la API (opcional, para operaciones CRUD)
+  final String nombre; // Nombre de la categoría (por ejemplo, "Inteligencia Artificial")
+  final String descripcion; // Descripción breve (por ejemplo, "Noticias sobre IA")
+                
+
+  Categoria({
+    this.id, // Puede ser null al crear una categoría, se asigna al guardarla
+    required this.nombre,
+    required this.descripcion,
+    
+    
+  });
+
+  // Método para convertir un JSON de la API a un objeto Category
+  factory Categoria.fromJson(Map<String, dynamic> json) {
+    return Categoria(
+      id: json['_id'] as String?, // El ID lo asigna CrudCrud
+      nombre: json['nombre'] as String,
+      descripcion: json['descripcion'] as String,
+      
+    );
+  }
+
+  // Método para convertir el objeto Category a JSON para enviar a la API
+  Map<String, dynamic> toJson() {
+    return {
+      'nombre': nombre,
+      'descripcion': descripcion,
+     
+    };
+  }
+}

--- a/lib/domain/entities/noticia.dart
+++ b/lib/domain/entities/noticia.dart
@@ -1,6 +1,6 @@
+import 'package:diego/constants/constants.dart';
 
 class Noticia {
-
   Noticia({
     this.id,
     required this.titulo,
@@ -8,6 +8,7 @@ class Noticia {
     required this.fuente,
     required this.publicadaEl,
     required this.urlImagen,
+    required this.categoriaId,
   });
 
   factory Noticia.fromJson(Map<String, dynamic> json) {
@@ -18,6 +19,7 @@ class Noticia {
       fuente: json['fuente'] ?? 'Fuente desconocida',
       publicadaEl: DateTime.parse(json['publicadaEl']),
       urlImagen: json['urlImagen'] ?? 'Sin imagen',
+      categoriaId: json['categoria'] ?? Constants.defaultCategoriaId, // ID de la categoría (opcional, para operaciones CRUD)
     );
   }
   final String? id;
@@ -26,4 +28,20 @@ class Noticia {
   final String fuente;
   final DateTime publicadaEl;
   final String urlImagen;
+  final String? categoriaId; // ID de la categoría (opcional, para operaciones CRUD)
+
+  // Método para obtener la categoría con valor por defecto
+  
+
+  // Método para convertir a JSON (útil para crear/actualizar noticias)
+  Map<String, dynamic> toJson() {
+    return {
+      'titulo': titulo,
+      'descripcion': descripcion,
+      'fuente': fuente,
+      'publicadaEl': publicadaEl.toIso8601String(),
+      'urlImagen': urlImagen,
+      'categoria': categoriaId, // ID de la categoría (opcional, para operaciones CRUD)
+    };
+  }
 }

--- a/lib/exceptions/api_exceptions.dart
+++ b/lib/exceptions/api_exceptions.dart
@@ -1,0 +1,12 @@
+class ApiException implements Exception {
+  final String message;
+
+  final int? statusCode;
+
+  ApiException(this.message, {this.statusCode});
+
+  @override
+  String toString() {
+    return 'ApiException: $message (Código: $statusCode)';
+  }
+}

--- a/lib/helpers/common_widgets_herlpers.dart
+++ b/lib/helpers/common_widgets_herlpers.dart
@@ -1,4 +1,5 @@
 import 'package:diego/constants/constants.dart';
+import 'package:diego/presentation/categorias_screen.dart';
 import 'package:diego/presentation/contador_screen.dart';
 import 'package:diego/presentation/login_screen.dart';
 import 'package:diego/presentation/quote_screen.dart';
@@ -114,6 +115,17 @@ class CommonWidgetsHelper {
               Navigator.push(
                 context,
                 MaterialPageRoute(builder: (context) => const NoticiaScreen()),
+              );
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.category),
+            title: const Text('Categorías'),
+            onTap: () {
+              // Acción para la configuración
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => const CategoriaScreen()),
               );
             },
           ),

--- a/lib/helpers/error_helper.dart
+++ b/lib/helpers/error_helper.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+class ErrorHelper {
+  /// Devuelve un mensaje y un color basado en el código HTTP
+  static Map<String, dynamic> getErrorMessageAndColor(int? statusCode) {
+    String message;
+    Color color;
+
+    switch (statusCode) {
+      case 400:
+        message = 'Solicitud incorrecta. Verifica los datos enviados.';
+        color = Colors.orange;
+        break;
+      case 401:
+        message = 'No autorizado. Verifica tus credenciales.';
+        color = Colors.red;
+        break;
+      case 403:
+        message = 'Prohibido. No tienes permisos para acceder.';
+        color = Colors.redAccent;
+        break;
+      case 404:
+        message = 'Recurso no encontrado. Verifica la URL.';
+        color = Colors.blueGrey;
+        break;
+      case 408:
+        message = 'Tiempo de espera agotado. Intenta nuevamente.';
+        color = Colors.amber;
+        break;
+      case 500:
+        message = 'Error interno del servidor. Intenta más tarde.';
+        color = Colors.red;
+        break;
+      default:
+        message = 'Ocurrió un error desconocido.';
+        color = Colors.grey;
+        break;
+    }
+
+    return {'message': message, 'color': color};
+  }
+}

--- a/lib/presentation/categorias_screen.dart
+++ b/lib/presentation/categorias_screen.dart
@@ -1,0 +1,273 @@
+import 'package:diego/api/service/categorias_service.dart';
+import 'package:diego/domain/entities/categoria.dart';
+import 'package:diego/exceptions/api_exceptions.dart';
+import 'package:diego/helpers/error_helper.dart';
+import 'package:flutter/material.dart';
+
+class CategoriaScreen extends StatefulWidget {
+  const CategoriaScreen({Key? key}) : super(key: key);
+
+  @override
+  _CategoriaScreenState createState() => _CategoriaScreenState();
+}
+
+class _CategoriaScreenState extends State<CategoriaScreen> {
+  final CategoriaService _categoriaService = CategoriaService();
+  List<Categoria> categorias = [];
+  bool isLoading = false;
+  bool hasError = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadCategorias();
+  }
+
+  Future<void> _loadCategorias() async {
+    setState(() {
+      isLoading = true;
+      hasError = false;
+    });
+
+    try {
+      final fetchedCategorias = await _categoriaService.getCategorias();
+      setState(() {
+        categorias = fetchedCategorias;
+        isLoading = false;
+      });
+    } catch (e) {
+      setState(() {
+        isLoading = false;
+        hasError = true;
+      });
+
+      String errorMessage = 'Error desconocido';
+      Color errorColor = Colors.grey;
+
+      if (e is ApiException) {
+        final errorData = ErrorHelper.getErrorMessageAndColor(e.statusCode);
+        errorMessage = errorData['message'];
+        errorColor = errorData['color'];
+      }
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(errorMessage), backgroundColor: errorColor),
+      );
+    }
+  }
+
+  Future<void> _agregarCategoria() async {
+    final nuevaCategoriaData = await _mostrarDialogCategoria(context);
+    if (nuevaCategoriaData != null) {
+      try {
+        // Crear un objeto Categoria a partir de los datos del diálogo
+        final nuevaCategoria = Categoria(
+          id: '', // El ID será generado por la API
+          nombre: nuevaCategoriaData['nombre'],
+          descripcion: nuevaCategoriaData['descripcion'],
+        );
+
+        await _categoriaService.crearCategoria(
+          nuevaCategoria,
+        ); // Llama al servicio
+        _loadCategorias(); // Recarga las categorías
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Categoría agregada exitosamente')),
+        );
+      } catch (e) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Error al agregar la categoría: $e')),
+        );
+      }
+    }
+  }
+
+  Future<Map<String, dynamic>?> _mostrarDialogCategoria(
+    BuildContext context, {
+    Categoria? categoria,
+  }) async {
+    final TextEditingController nombreController = TextEditingController(
+      text: categoria?.nombre ?? '',
+    );
+    final TextEditingController descripcionController = TextEditingController(
+      text: categoria?.descripcion ?? '',
+    );
+
+    return showDialog<Map<String, dynamic>>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text(
+            categoria == null ? 'Agregar Categoría' : 'Editar Categoría',
+          ),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextField(
+                controller: nombreController,
+                decoration: const InputDecoration(
+                  labelText: 'Nombre de la Categoría',
+                ),
+              ),
+              const SizedBox(height: 16),
+              TextField(
+                controller: descripcionController,
+                decoration: const InputDecoration(
+                  labelText: 'Descripción (opcional)',
+                ),
+                maxLines: 2,
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Cancelar'),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                if (nombreController.text.isNotEmpty) {
+                  Navigator.pop(context, {
+                    'nombre': nombreController.text,
+                    'descripcion': descripcionController.text,
+                  });
+                } else {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('El nombre no puede estar vacío'),
+                    ),
+                  );
+                }
+              },
+              child: const Text('Guardar'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Future<void> _editarCategoria(Categoria categoria) async {
+    final categoriaEditadaData = await _mostrarDialogCategoria(
+      context,
+      categoria: categoria,
+    );
+    if (categoriaEditadaData != null) {
+      try {
+        final categoriaEditada = Categoria(
+          id: categoria.id,
+          nombre: categoriaEditadaData['nombre'],
+          descripcion: categoriaEditadaData['descripcion'],
+        );
+
+        await _categoriaService.editarCategoria(categoriaEditada.id, categoriaEditada);
+        _loadCategorias();
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Categoría editada exitosamente')),
+        );
+      } catch (e) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Error al editar la categoría: $e')),
+        );
+      }
+    }
+  }
+
+  Future<void> _confirmarEliminarCategoria(Categoria categoria) async {
+    final confirmacion = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Confirmar eliminación'),
+          content: Text(
+            '¿Estás seguro de que deseas eliminar la categoría "${categoria.nombre}"?',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: const Text('Cancelar'),
+            ),
+            ElevatedButton(
+              onPressed: () => Navigator.pop(context, true),
+              child: const Text('Eliminar'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (confirmacion == true) {
+      try {
+        await _categoriaService.eliminarCategoria(categoria.id);
+        _loadCategorias();
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Categoría eliminada exitosamente')),
+        );
+      } catch (e) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Error al eliminar la categoría: $e')),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Categorías')),
+      body:
+          isLoading
+              ? const Center(child: CircularProgressIndicator())
+              : hasError
+              ? const Center(
+                child: Text(
+                  'Ocurrió un error al cargar las categorías.',
+                  style: TextStyle(color: Colors.red, fontSize: 16),
+                ),
+              )
+              : categorias.isEmpty
+              ? const Center(
+                child: Text(
+                  'No hay categorías disponibles.',
+                  style: TextStyle(fontSize: 16),
+                ),
+              )
+              : ListView.builder(
+                itemCount: categorias.length,
+                itemBuilder: (context, index) {
+                  final categoria = categorias[index];
+                  return ListTile(
+                    title: Text(categoria.nombre),
+                    subtitle: Text(
+                      categoria.descripcion.isEmpty
+                          ? 'ID: ${categoria.id}'
+                          : categoria.descripcion,
+                    ),
+                    leading: const Icon(Icons.category),
+                    trailing: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        IconButton(
+                          icon: const Icon(Icons.edit, color: Colors.blue),
+                          onPressed: () => _editarCategoria(categoria),
+                          tooltip: 'Editar categoría',
+                        ),
+                        IconButton(
+                          icon: const Icon(Icons.delete, color: Colors.red),
+                          onPressed:
+                              () => _confirmarEliminarCategoria(categoria),
+                          tooltip: 'Eliminar categoría',
+                        ),
+                      ],
+                    ),
+                  );
+                },
+              ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _agregarCategoria,
+        tooltip: 'Agregar Categoría',
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Agregada nueva entidad Categoría con sus correspondientes servicios y repositorio.
Implementado CRUD completo para Categorías
(crear, leer, actualizar, eliminar).
Mejorado manejo de errores con ErrorHelper para mostrar mensajes contextuales.
Añadido soporte para timeouts con mensaje personalizado (10 segundos) Integradas categorías en el modelo de Noticia
Añadida navegación entre pantallas de noticias y categorías Implementados SnackBars con colores específicos según tipo de error (400/500, 401, 404).
Mejorada la UI para mostrar categorías en noticias y permitir su gestión